### PR TITLE
use rip-relative addressing on x64

### DIFF
--- a/win/tkWin32Dll.c
+++ b/win/tkWin32Dll.c
@@ -135,7 +135,7 @@ DllMain(
 	    "leaq	%[registration], %%rdx"		"\n\t"
 	    "movq	%%gs:0,		%%rax"		"\n\t"
 	    "movq	%%rax,		0x0(%%rdx)"	"\n\t" /* link */
-	    "leaq	1f,		%%rax"		"\n\t"
+	    "leaq	1f(%%rip),	%%rax"		"\n\t"
 	    "movq	%%rax,		0x8(%%rdx)"	"\n\t" /* handler */
 	    "movq	%%rbp,		0x10(%%rdx)"	"\n\t" /* rbp */
 	    "movq	%%rsp,		0x18(%%rdx)"	"\n\t" /* rsp */


### PR DESCRIPTION
If the image base is greater than 4GB, the previous method results in a linker error
tkWin32Dll.o:tkWin32Dll.c:(.text+0x4d): relocation truncated to fit: R_X86_64_32S against `.text'

See https://stackoverflow.com/questions/57212012/how-to-load-address-of-function-or-label-into-register-in-gnu-assembler