### PR TITLE
added a Button-ID property (id widget) for the use in tkinter for pyt…

### DIFF
--- a/generic/tkButton.c
+++ b/generic/tkButton.c
@@ -140,6 +140,8 @@ static const Tk_OptionSpec labelOptionSpecs[] = {
 	TK_OPTION_NULL_OK, 0, 0},
     {TK_OPTION_STRING, "-text", "text", "Text",
 	DEF_BUTTON_TEXT, offsetof(TkButton, textPtr), TCL_INDEX_NONE, 0, 0, 0},
+    {TK_OPTION_STRING, "-id", "id", "Id",
+	DEF_BUTTON_ID, offsetof(TkButton, idPtr), TCL_INDEX_NONE, 0, 0, 0},
     {TK_OPTION_STRING, "-textvariable", "textVariable", "Variable",
 	DEF_BUTTON_TEXT_VARIABLE, offsetof(TkButton, textVarNamePtr), TCL_INDEX_NONE,
 	TK_OPTION_NULL_OK, 0, 0},
@@ -241,6 +243,8 @@ static const Tk_OptionSpec buttonOptionSpecs[] = {
 	TK_OPTION_NULL_OK, 0, 0},
     {TK_OPTION_STRING, "-text", "text", "Text",
 	DEF_BUTTON_TEXT, offsetof(TkButton, textPtr), TCL_INDEX_NONE, 0, 0, 0},
+    {TK_OPTION_STRING, "-id", "id", "Id",
+	DEF_BUTTON_ID, offsetof(TkButton, idPtr), TCL_INDEX_NONE, 0, 0, 0},
     {TK_OPTION_STRING, "-textvariable", "textVariable", "Variable",
 	DEF_BUTTON_TEXT_VARIABLE, offsetof(TkButton, textVarNamePtr), TCL_INDEX_NONE,
 	TK_OPTION_NULL_OK, 0, 0},
@@ -346,6 +350,8 @@ static const Tk_OptionSpec checkbuttonOptionSpecs[] = {
 	TK_OPTION_NULL_OK, 0, 0},
     {TK_OPTION_STRING, "-text", "text", "Text",
 	DEF_BUTTON_TEXT, offsetof(TkButton, textPtr), TCL_INDEX_NONE, 0, 0, 0},
+    {TK_OPTION_STRING, "-id", "id", "Id",
+	DEF_BUTTON_ID, offsetof(TkButton, idPtr), TCL_INDEX_NONE, 0, 0, 0},
     {TK_OPTION_STRING, "-textvariable", "textVariable", "Variable",
 	DEF_BUTTON_TEXT_VARIABLE, offsetof(TkButton, textVarNamePtr), TCL_INDEX_NONE,
 	TK_OPTION_NULL_OK, 0, 0},
@@ -456,6 +462,8 @@ static const Tk_OptionSpec radiobuttonOptionSpecs[] = {
 	TK_OPTION_NULL_OK, 0, 0},
     {TK_OPTION_STRING, "-text", "text", "Text",
 	DEF_BUTTON_TEXT, offsetof(TkButton, textPtr), TCL_INDEX_NONE, 0, 0, 0},
+    {TK_OPTION_STRING, "-id", "id", "Id",
+	DEF_BUTTON_ID, offsetof(TkButton, idPtr), TCL_INDEX_NONE, 0, 0, 0},
     {TK_OPTION_STRING, "-textvariable", "textVariable", "Variable",
 	DEF_BUTTON_TEXT_VARIABLE, offsetof(TkButton, textVarNamePtr), TCL_INDEX_NONE,
 	TK_OPTION_NULL_OK, 0, 0},
@@ -687,6 +695,7 @@ ButtonCreate(
     butPtr->type = type;
     butPtr->optionTable = optionTable;
     butPtr->textPtr = NULL;
+    butPtr->idPtr = NULL;
     butPtr->underline = -1;
     butPtr->textVarNamePtr = NULL;
     butPtr->bitmap = None;

--- a/generic/tkButton.h
+++ b/generic/tkButton.h
@@ -66,6 +66,8 @@ typedef struct {
 
     Tcl_Obj *textPtr;		/* Value of -text option: specifies text to
 				 * display in button. */
+    Tcl_Obj *idPtr;		/* Value of -id option: specifies an ID to
+				 * be used in button. */
     int underline;		/* Value of -underline option: specifies index
 				 * of character to underline. < 0 means don't
 				 * underline anything. */

--- a/generic/ttk/ttkButton.c
+++ b/generic/ttk/ttkButton.c
@@ -22,6 +22,7 @@ typedef struct
      * Text element resources:
      */
     Tcl_Obj *textObj;
+    Tcl_Obj *idObj;
     Tcl_Obj *justifyObj;
     Tcl_Obj *textVariableObj;
     Tcl_Obj *underlineObj;
@@ -61,6 +62,8 @@ static const Tk_OptionSpec BaseOptionSpecs[] =
         TK_OPTION_NULL_OK,0,GEOMETRY_CHANGED },
     {TK_OPTION_STRING, "-text", "text", "Text", "",
 	offsetof(Base,base.textObj), TCL_INDEX_NONE,
+    {TK_OPTION_STRING, "-id", "id", "Id", "",
+	offsetof(Base,base.idObj), TCL_INDEX_NONE,
 	0,0,GEOMETRY_CHANGED },
     {TK_OPTION_STRING, "-textvariable", "textVariable", "Variable", "",
 	offsetof(Base,base.textVariableObj), TCL_INDEX_NONE,


### PR DESCRIPTION
I added a Button-ID property (id widget) for the use in tkinter for python which can be used to identify the button by a string outside of the text widget. This allows the button to change text without loosing the possibility to identify the button. In fact the id is a copy of -text

I have written my Bachelor Final Work about this topic in 2019 and reviewed my work recently and still need such an id-property. I would like to have this property in tcl/tk to be used to identify a button without using the text-property for that since this can be changed or be redundant.

If you need mor information or would like to read my 56 pages paper on that, please contact me.