### PR TITLE
Try --disable-xft on macOS

### DIFF
--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Configure (symbols=${{ matrix.symbols }} ${{matrix.options }})
         # Note that macOS is always a 64 bit platform
         run: |
-          ./configure --enable-64bit ${CFGOPT} "--prefix=$HOME/install dir" || {
+          ./configure --enable-64bit ${CFGOPT} "--prefix=$HOME/install dir" --disable-xft || {
             cat config.log
             echo "::error::Failure during Configure"
             exit 1


### PR DESCRIPTION
Try --disable-xft when building Tk to confirm that the newly failing tests are due to xft now being suddenly available in the macOS Github environment (--enable-xft is the default).