### PR TITLE
enable tk package win/arm64 target

### DIFF
--- a/win/rules.vc
+++ b/win/rules.vc
@@ -435,6 +435,8 @@ VCVER=0
     && ![echo ARCH=IX86 >> vercl.x] \
     && ![echo $(_HASH)elif defined(_M_AMD64) >> vercl.x] \
     && ![echo ARCH=AMD64 >> vercl.x] \
+    && ![echo $(_HASH)elif defined(_M_ARM64) >> vercl.x] \
+    && ![echo ARCH=ARM64 >> vercl.x] \
     && ![echo $(_HASH)endif >> vercl.x] \
     && ![$(cc32) -nologo -TC -P vercl.x 2>NUL]
 !include vercl.i
@@ -462,6 +464,9 @@ MACHINE = IX86
 !elseif "$(MACHINE)" == "x64"
 !undef MACHINE
 MACHINE = AMD64
+!elseif "$(MACHINE)" == "arm64"
+!undef MACHINE
+MACHINE = ARM64
 !endif
 !if "$(MACHINE)" != "$(ARCH)"
 !error Specified MACHINE macro $(MACHINE) does not match detected target architecture $(ARCH).
@@ -475,6 +480,8 @@ MACHINE=$(ARCH)
 # the Tcl platform::identify command
 !if "$(MACHINE)" == "AMD64"
 PLATFORM_IDENTIFY = win32-x86_64
+!elseif "$(MACHINE)" == "ARM64"
+PLATFORM_IDENTIFY = win32-arm64
 !else
 PLATFORM_IDENTIFY = win32-ix86
 !endif
@@ -490,6 +497,8 @@ MULTIPLATFORM_INSTALL = 0
 
 !if ![reg query HKLM\Hardware\Description\System\CentralProcessor\0 /v Identifier | findstr /i x86]
 NATIVE_ARCH=IX86
+!elseif ![reg query HKLM\Hardware\Description\System\CentralProcessor\0 /v Identifier | findstr /i ARM | findstr /i 64-bit]
+NATIVE_ARCH=ARM64
 !else
 NATIVE_ARCH=AMD64
 !endif


### PR DESCRIPTION
Tcl changes for windows on arm64 is already merged to `core-8-6-branch` branch and this change will add support for `tk` package.