### PR TITLE
Update unixWm.test

### DIFF
--- a/tests/unixEmbed.test
+++ b/tests/unixEmbed.test
@@ -1293,37 +1293,36 @@ test unixEmbed-11.2 {mouse coordinates in embedded toplevels} -constraints {
 } -setup {
     deleteWindows
 } -body {
+    set result {}
     toplevel .main
     wm geometry .main 200x400+100+100
-    set result {}
-    pack [button .main.b -text "Main Button" \
-	    -command {lappend result "pushed .main.b"}] -padx 30 -pady 30
-    pack [frame .main.f -container 1 -width 200 -height 200] -fill both
+    update
+    frame .main.f -container 1 -width 200 -height 200
+    button .main.b -text "Main Button" -command {lappend result "pushed .main.b"}
+    pack .main.f -fill both
+    pack .main.b -padx 30 -pady 30
     update
     toplevel .embed -use [winfo id .main.f] -bg green
     update
-    pack [button .embed.b -text "Emb Button" \
-	    -command {lappend result "pushed .embed.b"}] -padx 30 -pady 30
+    button .embed.b -text "Emb Button" -command {lappend result "pushed .embed.b"}
+    pack .embed.b -padx 30 -pady 30
     update
     focus -force .main
-    after 100
+    update
     set x [expr {[winfo rootx .main.b] + [winfo width .main.b]/2}]
     set y [expr {[winfo rooty .main.b] + [winfo height .main.b]/2}]
     lappend result [winfo containing $x $y]
-    after 200
     pressbutton $x $y
     update
     set x [expr {[winfo rootx .embed.b] + [winfo width .embed.b]/2}]
     set y [expr {[winfo rooty .embed.b] + [winfo height .embed.b]/2}]
     lappend result [winfo containing $x $y]
-    after 200
     pressbutton $x $y
     update
     set result
 } -cleanup {
     deleteWindows
 } -result {.main.b {pushed .main.b} .embed.b {pushed .embed.b}}
-
 
 # cleanup
 deleteWindows

--- a/tests/unixWm.test
+++ b/tests/unixWm.test
@@ -1842,6 +1842,7 @@ test unixWm-50.2 {Tk_CoordsToWindow procedure, finding a toplevel, y-coords and 
     tkwait visibility .t2
     wm overrideredirect .t2 1
     wm geom .t2 +200+200
+    update
     raise .t2
     restackDelay
     set x [winfo rootx .t]

--- a/tests/unixWm.test
+++ b/tests/unixWm.test
@@ -1984,15 +1984,18 @@ test unixWm-50.9 {Tk_CoordsToWindow procedure, unmapped windows} {unix failsOnUb
     destroy .t2
     toplevel .t -width 200 -height 200 -bg green
     tkwait visibility .t
+    update
     wm geometry .t +0+0
-    update idletasks
+    update
     toplevel .t2 -width 200 -height 200 -bg red
     tkwait visibility .t2
+    update
     wm geometry .t2 +0+0
+    update
     restackDelay
     set result [list [winfo containing 100 100]]
     wm iconify .t2
-    update idletasks
+    update
     lappend result [winfo containing 100 100]
 } {.t2 .t}
 test unixWm-50.10 {Tk_CoordsToWindow procedure, unmapped windows} unix {


### PR DESCRIPTION
Testing if adding a call to update makes window .t2 get mapped in unixWm-50.2

Important Note
==========
Please do not file pull requests with Tk on Github. They are unlikely to be noticed in a timely fashion. Tk issues (including patches) are hosted in the [tk fossil repository on core.tcl-lang.org](https://core.tcl-lang.org/tk/tktnew); please post them there.
