### PR TITLE
Make treeview-rowheight-4 fail again on Linux due to missing cleanup …

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Run Tests
         run: |
           xvfb-run --auto-servernum make test-classic | tee out-classic.txt
-          xvfb-run --auto-servernum make test-ttk | tee out-ttk.txt
+          xvfb-run --auto-servernum make test-ttk TESTFLAGS="-verbose beps" | tee out-ttk.txt
           grep -q "Failed	0" out-classic.txt || {
             echo "::error::Failure during Test"
             exit 1

--- a/tests/ttk/treeview.test
+++ b/tests/ttk/treeview.test
@@ -1139,10 +1139,11 @@ test treeview-rowheight-2 "rowheight change" -body {
     update
     lindex [.tv bbox nn a] 3
 } -cleanup {
-    ttk::style configure Treeview -rowheight {}
+#    ttk::style configure Treeview -rowheight {}
 } -result 25
 
 test treeview-rowheight-3 "rowheight adapts to font" -constraints haveBigFontTwiceLargerThanTextFont -body {
+    ttk::style configure Treeview -rowheight {}
     ttk::style configure Treeview -font "Courier 12"
     update
     set baseline [lindex [.tv bbox nn a] 3]
@@ -1156,6 +1157,7 @@ test treeview-rowheight-3 "rowheight adapts to font" -constraints haveBigFontTwi
 } -result OK
 
 test treeview-rowheight-3b "rowheight adapts to named font" -constraints haveBigFontTwiceLargerThanTextFont -body {
+    ttk::style configure Treeview -rowheight {}
     font create __tf -family Courier -size 12
     ttk::style configure Treeview -font __tf
     update

--- a/tests/ttk/treeview.test
+++ b/tests/ttk/treeview.test
@@ -1123,6 +1123,8 @@ test treeview-identify-cleanup "identify - cleanup" -body {
     destroy .tv
 }
 
+puts [font actual {Courier 12}]
+puts [font actual {Helvetica 24}]
 
 test treeview-rowheight-1 "rowheight - setup" -body {
     destroy .tv


### PR DESCRIPTION
…in treeview-rowheight-2

Important Note
==========
Please do not file pull requests with Tk on Github. They are unlikely to be noticed in a timely fashion. Tk issues (including patches) are hosted in the [tk fossil repository on core.tcl-lang.org](https://core.tcl-lang.org/tk/tktnew); please post them there.
