### PR TITLE
xlib/X11/X.h - fix for x64 mingw-w64 ports of gcc.

### DIFF
--- a/xlib/X11/X.h
+++ b/xlib/X11/X.h
@@ -64,7 +64,11 @@ SOFTWARE.
 #  ifndef _XTYPEDEF_XID
 #    define _XTYPEDEF_XID
 #    ifdef _WIN64
+#      if defined(_MSC_VER)
 typedef unsigned __int64 XID;
+#      else
+typedef unsigned long long XID;
+#      endif
 #    else
 typedef unsigned long XID;
 #    endif


### PR DESCRIPTION
Important Note
==========
Please do not file pull requests with Tk on Github. They are unlikely to be noticed in a timely fashion. Tk issues (including patches) are hosted in the [tk fossil repository on core.tcl-lang.org](https://core.tcl-lang.org/tk/tktnew); please post them there.

If the Tk developers are really this committed to killing interest in Tk, then why not just remove the whole bloody lot and be done with it ?

Anyway, the PR has been made, so I might as well go ahead and submit it.
I'll also submit a report at https://core.tcl-lang.org/tk/tktnew when my anger has subsided. (Might take a day or two.)

<b>UPDATE:</b> This report is now duplicated at https://core.tcl-lang.org/tk/tktview/ff5417505be90f5abbbf6ea4c7a3ac3bae6bc8b1.